### PR TITLE
fix: AMB information request skip unknown error event

### DIFF
--- a/oracle/src/events/processAMBInformationRequests/calls/ethCall.js
+++ b/oracle/src/events/processAMBInformationRequests/calls/ethCall.js
@@ -18,7 +18,7 @@ function makeCall(argNames) {
       return [false, ASYNC_CALL_ERRORS.INPUT_DATA_HAVE_INCORRECT_FORMAT]
     })
     const { blockNumber, ...opts } = zipToObject(argNames, args)
-
+    
     if (blockNumber && toBN(blockNumber).gt(toBN(foreignBlock.number))) {
       return [false, ASYNC_CALL_ERRORS.BLOCK_IS_IN_THE_FUTURE]
     }
@@ -27,15 +27,18 @@ function makeCall(argNames) {
     if (!opts.gas || toBN(opts.gas).gt(toBN(ASYNC_ETH_CALL_MAX_GAS_LIMIT))) {
       opts.gas = ASYNC_ETH_CALL_MAX_GAS_LIMIT
     }
-
+  
     return web3.eth
       .call(opts, blockNumber || foreignBlock.number)
       .then(result => [true, web3.eth.abi.encodeParameter('bytes', result)])
       .catch(e => {
+  
         if (isRevertError(e)) {
+          logger.debug("Reverted error ")
           return [false, ASYNC_CALL_ERRORS.REVERT]
         }
-        throw e
+        return [false, ASYNC_CALL_ERRORS.NOT_FOUND ]
+       // throw e
       })
   }
 }

--- a/oracle/src/events/processAMBInformationRequests/calls/ethCall.js
+++ b/oracle/src/events/processAMBInformationRequests/calls/ethCall.js
@@ -17,9 +17,9 @@ function makeCall(argNames) {
     let args
     try{
       args = web3.eth.abi.decodeParameters(types, data)
-    } catch{() => {
+    } catch{
       return [false, ASYNC_CALL_ERRORS.INPUT_DATA_HAVE_INCORRECT_FORMAT]
-    }}
+    }
 
     const { blockNumber, ...opts } = zipToObject(argNames, args)
     

--- a/oracle/src/events/processAMBInformationRequests/calls/ethCall.js
+++ b/oracle/src/events/processAMBInformationRequests/calls/ethCall.js
@@ -14,9 +14,13 @@ const argTypes = {
 function makeCall(argNames) {
   return async function(web3, data, foreignBlock) {
     const types = argNames.map(name => argTypes[name])
-    const args = web3.eth.abi.decodeParameters(types, data).catch(() => {
+    let args
+    try{
+      args = web3.eth.abi.decodeParameters(types, data)
+    } catch{() => {
       return [false, ASYNC_CALL_ERRORS.INPUT_DATA_HAVE_INCORRECT_FORMAT]
-    })
+    }}
+
     const { blockNumber, ...opts } = zipToObject(argNames, args)
     
     if (blockNumber && toBN(blockNumber).gt(toBN(foreignBlock.number))) {

--- a/oracle/src/events/processAMBInformationRequests/calls/ethGetBalance.js
+++ b/oracle/src/events/processAMBInformationRequests/calls/ethGetBalance.js
@@ -3,9 +3,12 @@ const { toBN } = require('web3').utils
 const { ASYNC_CALL_ERRORS } = require('../../../utils/constants')
 
 async function call(web3, data, foreignBlock) {
-  const address = web3.eth.abi.decodeParameter('address', data).catch(() => {
+  let address
+  try{
+    address = web3.eth.abi.decodeParameter('address', data)
+  }catch{() => {
     return [false, ASYNC_CALL_ERRORS.INPUT_DATA_HAVE_INCORRECT_FORMAT]
-  })
+  }}
 
   const balance = await web3.eth.getBalance(address, foreignBlock.number)
 

--- a/oracle/src/events/processAMBInformationRequests/calls/ethGetBalance.js
+++ b/oracle/src/events/processAMBInformationRequests/calls/ethGetBalance.js
@@ -6,9 +6,9 @@ async function call(web3, data, foreignBlock) {
   let address
   try{
     address = web3.eth.abi.decodeParameter('address', data)
-  }catch{() => {
+  }catch{
     return [false, ASYNC_CALL_ERRORS.INPUT_DATA_HAVE_INCORRECT_FORMAT]
-  }}
+  }
 
   const balance = await web3.eth.getBalance(address, foreignBlock.number)
 

--- a/oracle/src/events/processAMBInformationRequests/calls/ethGetBlockByHash.js
+++ b/oracle/src/events/processAMBInformationRequests/calls/ethGetBlockByHash.js
@@ -3,13 +3,15 @@ const { serializeBlock } = require('./serializers')
 
 async function call(web3, data, foreignBlock) {
   let blockHash
+  
   try{
     blockHash = web3.eth.abi.decodeParameter('bytes32', data)
-  }catch{() => {
+  }catch{
     return [false, ASYNC_CALL_ERRORS.INPUT_DATA_HAVE_INCORRECT_FORMAT]
-  }}
-
-  const block = await web3.eth.getBlock(blockHash)
+  }
+  
+    const block = await web3.eth.getBlock(blockHash)
+ 
 
   if (block === null || block.number > foreignBlock.number) {
     return [false, ASYNC_CALL_ERRORS.NOT_FOUND]

--- a/oracle/src/events/processAMBInformationRequests/calls/ethGetBlockByHash.js
+++ b/oracle/src/events/processAMBInformationRequests/calls/ethGetBlockByHash.js
@@ -2,9 +2,12 @@ const { ASYNC_CALL_ERRORS } = require('../../../utils/constants')
 const { serializeBlock } = require('./serializers')
 
 async function call(web3, data, foreignBlock) {
-  const blockHash = web3.eth.abi.decodeParameter('bytes32', data).catch(() => {
+  let blockHash
+  try{
+    blockHash = web3.eth.abi.decodeParameter('bytes32', data)
+  }catch{() => {
     return [false, ASYNC_CALL_ERRORS.INPUT_DATA_HAVE_INCORRECT_FORMAT]
-  })
+  }}
 
   const block = await web3.eth.getBlock(blockHash)
 

--- a/oracle/src/events/processAMBInformationRequests/calls/ethGetBlockByNumber.js
+++ b/oracle/src/events/processAMBInformationRequests/calls/ethGetBlockByNumber.js
@@ -7,15 +7,20 @@ async function call(web3, data, foreignBlock) {
   let blockNumber
   try{
     blockNumber = web3.eth.abi.decodeParameter('uint256', data)
-  }catch{() => {
+  }catch{
     return [false, ASYNC_CALL_ERRORS.INPUT_DATA_HAVE_INCORRECT_FORMAT]
-  }}
+  }
 
   if (toBN(blockNumber).gt(toBN(foreignBlock.number))) {
     return [false, ASYNC_CALL_ERRORS.BLOCK_IS_IN_THE_FUTURE]
   }
 
   const block = await web3.eth.getBlock(blockNumber)
+
+  if (block === null || block.number > foreignBlock.number) {
+    return [false, ASYNC_CALL_ERRORS.NOT_FOUND]
+  }
+
 
   return [true, serializeBlock(web3, block)]
 }

--- a/oracle/src/events/processAMBInformationRequests/calls/ethGetBlockByNumber.js
+++ b/oracle/src/events/processAMBInformationRequests/calls/ethGetBlockByNumber.js
@@ -4,9 +4,12 @@ const { ASYNC_CALL_ERRORS } = require('../../../utils/constants')
 const { serializeBlock } = require('./serializers')
 
 async function call(web3, data, foreignBlock) {
-  const blockNumber = web3.eth.abi.decodeParameter('uint256', data).catch(() => {
+  let blockNumber
+  try{
+    blockNumber = web3.eth.abi.decodeParameter('uint256', data)
+  }catch{() => {
     return [false, ASYNC_CALL_ERRORS.INPUT_DATA_HAVE_INCORRECT_FORMAT]
-  })
+  }}
 
   if (toBN(blockNumber).gt(toBN(foreignBlock.number))) {
     return [false, ASYNC_CALL_ERRORS.BLOCK_IS_IN_THE_FUTURE]

--- a/oracle/src/events/processAMBInformationRequests/calls/ethGetStorageAt.js
+++ b/oracle/src/events/processAMBInformationRequests/calls/ethGetStorageAt.js
@@ -4,30 +4,46 @@ const { ASYNC_CALL_ERRORS } = require('../../../utils/constants')
 
 async function call(web3, data, foreignBlock) {
   let address, slot
+  let value
   try{
   const decoded = web3.eth.abi.decodeParameters(['address', 'bytes32'], data)
   address = decoded[0]
   slot = decoded[1]
-  }catch{() => {
+  }catch{
     return [false, ASYNC_CALL_ERRORS.INPUT_DATA_HAVE_INCORRECT_FORMAT]
-  }}
+  }
 
-  const value = await web3.eth.getStorageAt(address, slot, foreignBlock.number)
+  try{
+    value = await web3.eth.getStorageAt(address, slot, foreignBlock.number)
+  }catch{
+    return [false,ASYNC_CALL_ERRORS.FAIL_TO_GET_STORAGE]
+  }
 
   return [true, web3.eth.abi.encodeParameter('bytes32', value)]
 }
 
 async function callArchive(web3, data, foreignBlock) {
-  const { 0: address, 1: slot, 2: blockNumber } = web3.eth.abi.decodeParameters(['address', 'bytes32', 'uint256'], data).catch(() => {
+  let address, slot, blockNumber
+  let value
+  try{
+    const decoded = web3.eth.abi.decodeParameters(['address', 'bytes32', 'uint256'], data)
+    address = decoded[0]
+    slot = decoded[1]
+    blockNumber = decoded[2]
+  }catch{
     return [false, ASYNC_CALL_ERRORS.INPUT_DATA_HAVE_INCORRECT_FORMAT]
-  })
+  }
 
   if (toBN(blockNumber).gt(toBN(foreignBlock.number))) {
     return [false, ASYNC_CALL_ERRORS.BLOCK_IS_IN_THE_FUTURE]
   }
 
-  const value = await web3.eth.getStorageAt(address, slot, blockNumber)
-
+  try{
+    value = await web3.eth.getStorageAt(address, slot, blockNumber)
+  }catch{
+    return [false,ASYNC_CALL_ERRORS.FAIL_TO_GET_STORAGE]
+  }
+  
   return [true, web3.eth.abi.encodeParameter('bytes32', value)]
 }
 

--- a/oracle/src/events/processAMBInformationRequests/calls/ethGetStorageAt.js
+++ b/oracle/src/events/processAMBInformationRequests/calls/ethGetStorageAt.js
@@ -3,9 +3,14 @@ const { toBN } = require('web3').utils
 const { ASYNC_CALL_ERRORS } = require('../../../utils/constants')
 
 async function call(web3, data, foreignBlock) {
-  const { 0: address, 1: slot } = web3.eth.abi.decodeParameters(['address', 'bytes32'], data).catch(() => {
+  let address, slot
+  try{
+  const decoded = web3.eth.abi.decodeParameters(['address', 'bytes32'], data)
+  address = decoded[0]
+  slot = decoded[1]
+  }catch{() => {
     return [false, ASYNC_CALL_ERRORS.INPUT_DATA_HAVE_INCORRECT_FORMAT]
-  })
+  }}
 
   const value = await web3.eth.getStorageAt(address, slot, foreignBlock.number)
 

--- a/oracle/src/events/processAMBInformationRequests/calls/ethGetTransactionByHash.js
+++ b/oracle/src/events/processAMBInformationRequests/calls/ethGetTransactionByHash.js
@@ -2,9 +2,12 @@ const { ASYNC_CALL_ERRORS } = require('../../../utils/constants')
 const { serializeTx } = require('./serializers')
 
 async function call(web3, data, foreignBlock) {
-  const hash = web3.eth.abi.decodeParameter('bytes32', data).catch(() => {
+  let hash
+  try{
+    hash = web3.eth.abi.decodeParameter('bytes32', data)
+  }catch{() => {
     return [false, ASYNC_CALL_ERRORS.INPUT_DATA_HAVE_INCORRECT_FORMAT]
-  })
+  }}
 
   const tx = await web3.eth.getTransaction(hash)
 

--- a/oracle/src/events/processAMBInformationRequests/calls/ethGetTransactionByHash.js
+++ b/oracle/src/events/processAMBInformationRequests/calls/ethGetTransactionByHash.js
@@ -5,9 +5,9 @@ async function call(web3, data, foreignBlock) {
   let hash
   try{
     hash = web3.eth.abi.decodeParameter('bytes32', data)
-  }catch{() => {
+  }catch{
     return [false, ASYNC_CALL_ERRORS.INPUT_DATA_HAVE_INCORRECT_FORMAT]
-  }}
+  }
 
   const tx = await web3.eth.getTransaction(hash)
 

--- a/oracle/src/events/processAMBInformationRequests/calls/ethGetTransactionCount.js
+++ b/oracle/src/events/processAMBInformationRequests/calls/ethGetTransactionCount.js
@@ -3,9 +3,12 @@ const { toBN } = require('web3').utils
 const { ASYNC_CALL_ERRORS } = require('../../../utils/constants')
 
 async function call(web3, data, foreignBlock) {
-  const address = web3.eth.abi.decodeParameter('address', data).catch(() => {
+  let address
+  try{
+    address = web3.eth.abi.decodeParameter('address', data)
+  }catch{() => {
     return [false, ASYNC_CALL_ERRORS.INPUT_DATA_HAVE_INCORRECT_FORMAT]
-  })
+  }}
 
   const nonce = await web3.eth.getTransactionCount(address, foreignBlock.number)
 
@@ -13,9 +16,14 @@ async function call(web3, data, foreignBlock) {
 }
 
 async function callArchive(web3, data, foreignBlock) {
-  const { 0: address, 1: blockNumber } = web3.eth.abi.decodeParameters(['address', 'uint256'], data).catch(() => {
+  let address,blockNumber
+ try{
+  const decoded = web3.eth.abi.decodeParameters(['address', 'uint256'], data)
+  address = decoded[0]
+  blocknumber = decoded[1]
+}catch{() => {
     return [false, ASYNC_CALL_ERRORS.INPUT_DATA_HAVE_INCORRECT_FORMAT]
-  })
+  }}
 
   if (toBN(blockNumber).gt(toBN(foreignBlock.number))) {
     return [false, ASYNC_CALL_ERRORS.BLOCK_IS_IN_THE_FUTURE]

--- a/oracle/src/events/processAMBInformationRequests/calls/ethGetTransactionCount.js
+++ b/oracle/src/events/processAMBInformationRequests/calls/ethGetTransactionCount.js
@@ -4,32 +4,42 @@ const { ASYNC_CALL_ERRORS } = require('../../../utils/constants')
 
 async function call(web3, data, foreignBlock) {
   let address
+  let nonce
   try{
     address = web3.eth.abi.decodeParameter('address', data)
-  }catch{() => {
+  }catch{
     return [false, ASYNC_CALL_ERRORS.INPUT_DATA_HAVE_INCORRECT_FORMAT]
-  }}
-
-  const nonce = await web3.eth.getTransactionCount(address, foreignBlock.number)
+  }
+  try{
+    nonce = await web3.eth.getTransactionCount(address, foreignBlock.number)
+  }catch{
+    return [false, ASYNC_CALL_ERRORS.FAIL_TO_GET_TX_COUNT]
+  }
+   
 
   return [true, web3.eth.abi.encodeParameter('uint256', nonce)]
 }
 
 async function callArchive(web3, data, foreignBlock) {
   let address,blockNumber
- try{
-  const decoded = web3.eth.abi.decodeParameters(['address', 'uint256'], data)
-  address = decoded[0]
-  blocknumber = decoded[1]
-}catch{() => {
+  let nonce
+  try{
+    const decoded = web3.eth.abi.decodeParameters(['address', 'uint256'], data)
+    address = decoded[0]
+    blockNumber = decoded[1]
+  }catch{
     return [false, ASYNC_CALL_ERRORS.INPUT_DATA_HAVE_INCORRECT_FORMAT]
-  }}
+  }
 
   if (toBN(blockNumber).gt(toBN(foreignBlock.number))) {
     return [false, ASYNC_CALL_ERRORS.BLOCK_IS_IN_THE_FUTURE]
   }
 
-  const nonce = await web3.eth.getTransactionCount(address, blockNumber)
+  try{
+    nonce = await web3.eth.getTransactionCount(address, foreignBlock.number)
+  }catch{
+    return [false, ASYNC_CALL_ERRORS.FAIL_TO_GET_TX_COUNT]
+  }
 
   return [true, web3.eth.abi.encodeParameter('uint256', nonce)]
 }

--- a/oracle/src/events/processAMBInformationRequests/calls/ethGetTransactionReceipt.js
+++ b/oracle/src/events/processAMBInformationRequests/calls/ethGetTransactionReceipt.js
@@ -2,9 +2,12 @@ const { ASYNC_CALL_ERRORS } = require('../../../utils/constants')
 const { serializeReceipt } = require('./serializers')
 
 async function call(web3, data, foreignBlock) {
-  const hash = web3.eth.abi.decodeParameter('bytes32', data).catch(() => {
+  let hash
+  try{
+    hash = web3.eth.abi.decodeParameter('bytes32', data)
+  }catch{() => {
     return [false, ASYNC_CALL_ERRORS.INPUT_DATA_HAVE_INCORRECT_FORMAT]
-  })
+  }}
 
   const receipt = await web3.eth.getTransactionReceipt(hash)
 

--- a/oracle/src/events/processAMBInformationRequests/calls/ethGetTransactionReceipt.js
+++ b/oracle/src/events/processAMBInformationRequests/calls/ethGetTransactionReceipt.js
@@ -5,9 +5,9 @@ async function call(web3, data, foreignBlock) {
   let hash
   try{
     hash = web3.eth.abi.decodeParameter('bytes32', data)
-  }catch{() => {
+  }catch{
     return [false, ASYNC_CALL_ERRORS.INPUT_DATA_HAVE_INCORRECT_FORMAT]
-  }}
+  }
 
   const receipt = await web3.eth.getTransactionReceipt(hash)
 

--- a/oracle/src/events/processAMBInformationRequests/index.js
+++ b/oracle/src/events/processAMBInformationRequests/index.js
@@ -73,6 +73,7 @@ function processInformationRequestsBuilder(config) {
     rootLogger.debug(`Processing ${informationRequests.length} UserRequestForInformation events`)
     const callbacks = informationRequests
       .map(informationRequest => async () => {
+      
         const { messageId, requestSelector, data } = informationRequest.returnValues
 
         const logger = rootLogger.child({
@@ -84,7 +85,7 @@ function processInformationRequestsBuilder(config) {
 
         if (!asyncCallMethod) {
           logger.warn({ requestSelector }, 'Unknown async request selector received')
-          return
+          return [null]
         }
         logger.info({ requestSelector, method: asyncCallMethod, data }, 'Processing async request')
 
@@ -94,9 +95,10 @@ function processInformationRequestsBuilder(config) {
             throw e
           }
           logger.error({ error: e.message }, 'Unknown error during async call execution')
-          throw e
+          return [null]
+          // throw e
         })
-        if (result.length > 2 + MAX_ASYNC_CALL_RESULT_LENGTH * 2) {
+        if (result && result.length > 2 + MAX_ASYNC_CALL_RESULT_LENGTH * 2) {
           status = false
           result = ASYNC_CALL_ERRORS.RESULT_IS_TOO_LONG
         }
@@ -130,7 +132,8 @@ function processInformationRequestsBuilder(config) {
             return
           } else {
             logger.error(e, 'Unknown error while processing transaction')
-            throw e
+            return [null]
+            // throw e
           }
         }
 

--- a/oracle/src/utils/constants.js
+++ b/oracle/src/utils/constants.js
@@ -32,15 +32,29 @@ module.exports = {
   SENDER_QUEUE_CHECK_STATUS_PRIORITY: 1,
   ASYNC_CALL_ERRORS: {
     // requested transaction/block/receipt does not exist
-    NOT_FOUND: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    // keccak256(NOT_FOUND)
+    NOT_FOUND: '0x7bafae6429a8b3ef0db181af7c5834a6f2b1af33146a1a9ae02e833d27f2431b',
     // requested custom block does not exist yet or its timestamp is greater than the home block timestamp
-    BLOCK_IS_IN_THE_FUTURE: '0x0000000000000000000000000000000000000000000000000000000000000001',
+    // keccak256(BLOCK_IS_IN_THE_FUTURE)
+    BLOCK_IS_IN_THE_FUTURE: '0x0df7256838069bd10086ae11040abd6778b2f4e5afd247cd1442352c11c49d63',
     // eth_call has reverted or finished with OOG error
-    REVERT: '0x0000000000000000000000000000000000000000000000000000000000000002',
+    // keccak256(REVERT)
+    REVERT: 'e13872d662304a4be4efe6d4425b00781f90609ddf2ef6e5b5e5c8bc7f5ed47f',
     // evaluated output length exceeds allowed length of 64 KB
-    RESULT_IS_TOO_LONG: '0x0000000000000000000000000000000000000000000000000000000000000003',
+    // keccak256(RESULT_IS_TOO_LONG)
+    RESULT_IS_TOO_LONG: '0x8e2ceb0f95a927556fde88310291fd5ada8156512a6dcb0cfb902c01939d3c01',
     // incorrect format of data to be decoded in request processing
-    INPUT_DATA_HAVE_INCORRECT_FORMAT: '0x0000000000000000000000000000000000000000000000000000000000000004'
+    // keccak256(INPUT_DATA_HAVE_INCORRECT_FORMAT)
+    INPUT_DATA_HAVE_INCORRECT_FORMAT: '0x8a93ece638d538b80a40bbcb6aae37b7537187c25360bd4b921762c59c165005',
+    // Unknown error when processing the async request
+    // keccak256(UNKNOWN_ERROR)
+    UNKNOWN_ERROR: '0x1025faf2318c4777ee95a1387b6e521fccc5fd2cb493f8ba3c1bc85d5fee0539',
+    // fail the fetch storage using getStorageAt
+    // keccak256(FAIL_TO_GET_STORAGE)
+    FAIL_TO_GET_STORAGE: '0x12d1c19a1ff9a4e68a7260d3ee57e12407ab9293dddf192c7e54309b85e4841f',
+    // fail the fetch transaction count using getTransactionCount
+    // keccak256(FAIL_TO_GET_TX_COUNT)
+    FAIL_TO_GET_TX_COUNT: '0x84d7a74d7049c0a2c1a15404623fe9a4d174e705371e6822dbf40614497e0c6b'
   },
   MAX_ASYNC_CALL_RESULT_LENGTH: 64 * 1024,
   ASYNC_ETH_CALL_MAX_GAS_LIMIT: 100000000

--- a/oracle/src/watcher.js
+++ b/oracle/src/watcher.js
@@ -281,15 +281,17 @@ async function main({ sendToQueue }) {
         }
 
         job = await processAMBInformationRequests(events)
-        if (job === null) {
+        if(job === null){
+          logger.debug("No job to send")
           return
         }
+    
       } else {
         job = await processEvents(events)
       }
-      logger.info('Transactions to send:', job.length)
 
-      if (job.length) {
+      if (job!=null && job.length > 0){
+        logger.info('Transactions to send:', job.length)
         await sendToQueue(job)
       }
       if (reprocessingOptions.enabled) {


### PR DESCRIPTION
# What

This PR proposes a change in the `processAMBInformationRequests` to enable skipping the process of unknown error event, instead of throwing error and stopping the oracle. 

If unknown error occurs in the information request process, it will show the error message and return null, instead of throwing error and restarting the process. `lastProcessedBlock` will be updated to the block number of the error event, so that oracle will not process the same error message again.