### PR TITLE
fix(oracle): error in token type matching

### DIFF
--- a/oracle/src/events/processSignatureRequests/index.js
+++ b/oracle/src/events/processSignatureRequests/index.js
@@ -36,7 +36,7 @@ function processSignatureRequestsBuilder(config) {
       .map(signatureRequest => async () => {
         const { recipient, value, nonce, token } = signatureRequest.returnValues
 
-        if (token !== DAI_ADDRESS || token !== USDS_ADDRESS) {
+        if (token !== DAI_ADDRESS && token !== USDS_ADDRESS) {
           return
         }
 


### PR DESCRIPTION
The original check will always result in `return` because it will either be DAI or USDS. 
Should return only when token address is not DAI and USDS.