### PR TITLE
native arm64 builds and other ci features

### DIFF
--- a/.github/workflows/oracle_build_image.yml
+++ b/.github/workflows/oracle_build_image.yml
@@ -11,17 +11,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  publish:
+  # Step 1: Resolve the version tag. This must be its own job because the build
+  # job below calls a reusable workflow (`uses:`), and such jobs cannot also run
+  # `steps:`. The version is exposed as an output for the build & notify jobs.
+  version:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 60          # multi-arch arm64 builds under emulation are slow
+    timeout-minutes: 5
     outputs:
       version: ${{ steps.get_tag.outputs.version }}
     steps:
-      # Step 1: Checkout the repository
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      
+
       # Pointing to old repo of contracts: TODO add ABIS from tokenbridge-contracts
       # - name: Checkout
       #   uses: actions/checkout@v2
@@ -30,7 +32,6 @@ jobs:
       #     path: ./contracts
       #     ref: 908a48107919d4ab127f9af07d44d47eac91547e
 
-      # Step 2: Extract version tag
       - name: Get current version tag
         id: get_tag
         run: |
@@ -38,40 +39,46 @@ jobs:
           latest_tag=$(git describe --tags "$(git rev-list --tags --max-count=1)")
           echo "version=$latest_tag" >> "$GITHUB_OUTPUT"
 
-      # Step 3: Login to Docker Hub
-      - name: Login to Docker Hub
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
+  # Step 2: Build & push the multi-arch image via Docker's official GitHub Builder
+  # reusable workflow. distribute:true (default) builds each platform on its own
+  # NATIVE runner (arm64 -> ubuntu-24.04-arm), replacing the slow QEMU emulation.
+  # Dropping the old no-cache:true in favour of the signed GHA cache is the single
+  # biggest speedup here. Also emits signed SLSA provenance + an SBOM.
+  publish:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    needs: version
+    permissions:
+      contents: read
+      id-token: write          # required for signed SLSA provenance attestation
+    uses: docker/github-builder/.github/workflows/build.yml@70ac3fc303efa83d2b94905e6ab78bb83cbdc2ae # v1.11.0
+    with:
+      output: image
+      push: true
+      platforms: linux/amd64,linux/arm64
+      file: ./oracle/Dockerfile
+      context: .
+      cache: true
+      cache-mode: max
+      sbom: true
+      set-meta-labels: true
+      meta-images: gnosischain/tokenbridge-oracle
+      meta-tags: |
+        type=raw,value=${{ needs.version.outputs.version }}
+        type=raw,value=latest
+    secrets:
+      registry-auths: |
+        - registry: docker.io
           username: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }}
 
-      # Step 4: Set up QEMU (enables arm64 emulation on the amd64 runner)
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
-
-      # Step 5: Set up Docker Buildx
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-
-      # Step 6: Build and push multi-arch Docker image
-      - name: Build and push Docker image
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        with:
-          context: .
-          file: ./oracle/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          no-cache: true
-          tags: gnosischain/tokenbridge-oracle:${{ steps.get_tag.outputs.version }},gnosischain/tokenbridge-oracle:latest
-
   notify:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    needs: publish
+    needs: [version, publish]
     uses: ./.github/workflows/slack_release_notification.yml
-    secrets: 
+    secrets:
       RELEASES_SLACK_WEBHOOK_URL: ${{ secrets.RELEASES_SLACK_WEBHOOK_URL }}
     with:
       environment: Production
       service: Tokenbridge Oracle
       success: ${{ contains(join(needs.*.result, ','), 'success') }}
-      message: "Released new docker image of `Tokenbridge Oracle` version `${{ needs.publish.outputs.version }}`. Triggered by `${{ github.actor }}`. Docker image: https://hub.docker.com/r/gnosischain/tokenbridge-oracle/tags?name=`${{ needs.publish.outputs.version }}`."
+      message: "Released new docker image of `Tokenbridge Oracle` version `${{ needs.version.outputs.version }}`. Triggered by `${{ github.actor }}`. Docker image: https://hub.docker.com/r/gnosischain/tokenbridge-oracle/tags?name=${{ needs.version.outputs.version }}."


### PR DESCRIPTION
native arm64 builds on ubuntu-24.04-arm (no emulation, parallel per-arch, free on public repos), GHA layer cache, and signed SLSA provenance + SBOM